### PR TITLE
Update models.json and change Docker base images to Debian 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # ---------------------------------------
 # Base image for node
-FROM node:19-slim as node_base
+FROM node:19-bullseye-slim as node_base
 
 WORKDIR /usr/src/app
 
 # ---------------------------------------
 # Base image for runtime
-FROM python:3.11-slim as base
+FROM python:3.11-slim-bullseye as base
 
 ENV TZ=Etc/UTC
 WORKDIR /usr/src/app

--- a/api/src/serge/data/models.json
+++ b/api/src/serge/data/models.json
@@ -72,14 +72,9 @@
                 "repo": "TheBloke/chronos-hermes-13B-GGML",
                 "files": [
                     {
-                        "name": "q2_K",
-                        "filename": "chronos-hermes-13b.ggmlv3.q2_K.bin",
-                        "disk_space": 55100000000.0
-                    },
-                    {
-                        "name": "q3_K_L",
-                        "filename": "chronos-hermes-13b.ggmlv3.q3_K_L.bin",
-                        "disk_space": 69300000000.0
+                        "name": "q4_0",
+                        "filename": "chronos-hermes-13b.ggmlv3.q4_0.bin",
+                        "disk_space": 73200000000.0
                     },
                     {
                         "name": "q4_1",
@@ -87,24 +82,14 @@
                         "disk_space": 81400000000.0
                     },
                     {
-                        "name": "q4_K_M",
-                        "filename": "chronos-hermes-13b.ggmlv3.q4_K_M.bin",
-                        "disk_space": 78700000000.0
+                        "name": "q5_0",
+                        "filename": "chronos-hermes-13b.ggmlv3.q5_0.bin",
+                        "disk_space": 89500000000.0
                     },
                     {
                         "name": "q5_1",
                         "filename": "chronos-hermes-13b.ggmlv3.q5_1.bin",
                         "disk_space": 97600000000.0
-                    },
-                    {
-                        "name": "q5_K_M",
-                        "filename": "chronos-hermes-13b.ggmlv3.q5_K_M.bin",
-                        "disk_space": 92300000000.0
-                    },
-                    {
-                        "name": "q6_K",
-                        "filename": "chronos-hermes-13b.ggmlv3.q6_K.bin",
-                        "disk_space": 10700000000.0
                     },
                     {
                       "name": "q8_0",


### PR DESCRIPTION
- Both llama.cpp and llama-cpp-python have issues compiling with Debian 12. Lets pin the image to debian-11 until a fix is found.
- Update models.json

Fixes #453 