### PR TITLE
Refactor production Dockerfile, Add development Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,9 @@ npm-debug.log
 .aws
 
 **/.ruff_cache/
+**/node_modules/
+**/dist
+**/.mypy_cache/
 __pycache__
 *.pyc
 *.pyo

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ api/static/*
 **/.ruff_cache/
 **/node_modules/
 **/dist
+**/.mypy_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,8 @@ RUN apt-get update \
 FROM node_base as frontend_builder
 
 WORKDIR /usr/src/app
-ENV NODE_ENV='production'
 COPY ./web/package.json ./web/package-lock.json ./
-RUN npm ci --production
+RUN npm ci
 
 COPY ./web /usr/src/app/web/
 WORKDIR /usr/src/app/web/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -23,34 +23,19 @@ RUN apt-get update \
     && echo "dir /data/db/" >> /etc/redis/redis.conf
 
 # ---------------------------------------
-# Build frontend
-FROM node_base as frontend_builder
-
-WORKDIR /usr/src/app
-ENV NODE_ENV='production'
-COPY ./web/package.json ./web/package-lock.json ./
-RUN npm ci --production
-
-COPY ./web /usr/src/app/web/
-WORKDIR /usr/src/app/web/
-RUN npm run build
-
-# ---------------------------------------
-# Runtime environment
-FROM base as release
+# Dev environment
+FROM base as dev
 
 # Set ENV
-ENV NODE_ENV='production'
 WORKDIR /usr/src/app
+ENV NODE_ENV='development'
 
-# Copy artifacts
-COPY --from=frontend_builder /usr/src/app/web/build /usr/src/app/api/static/
-COPY ./api /usr/src/app/api
-COPY scripts/deploy.sh /usr/src/app/deploy.sh
+# Install node.js and npm packages
+COPY --from=node_base /usr/local /usr/local
+COPY scripts/dev.sh /usr/src/app/dev.sh
+COPY ./web/package.json ./web/package-lock.json ./
 
-# Install api dependencies
-RUN pip install --no-cache-dir ./api \
-    && chmod 755 /usr/src/app/deploy.sh
+RUN npm ci \
+    && chmod 755 /usr/src/app/dev.sh
 
-EXPOSE 8008
-CMD ./deploy.sh
+CMD ./dev.sh

--- a/README.md
+++ b/README.md
@@ -186,5 +186,5 @@ To run Serge in development mode:
 
 ```bash
 git clone https://github.com/serge-chat/serge.git
-DOCKER_BUILDKIT=1 docker compose -f docker-compose.dev.yml up -d --build
+docker compose -f docker-compose.dev.yml up -d --build
 ```

--- a/api/test/healthcheck_models.py
+++ b/api/test/healthcheck_models.py
@@ -1,9 +1,9 @@
 import json
-import requests
+from pathlib import Path
+
 import huggingface_hub
 import pytest
-
-from pathlib import Path
+import requests
 
 # this test file specifically doesn't start with test_* so it's not picked up by pytest
 

--- a/config/redis.conf
+++ b/config/redis.conf
@@ -1,2 +1,0 @@
-appendonly yes
-dir /data/db/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -3,8 +3,7 @@ services:
     restart: on-failure
     build: 
       context: .
-      dockerfile: Dockerfile
-      target: dev
+      dockerfile: Dockerfile.dev
     volumes:
       - ./web:/usr/src/app/web/
       - ./api:/usr/src/app/api/


### PR DESCRIPTION
- Added separate Dockerfile for doing development
- Refactored some of the commands used in the Dockerfile
- Removed the need for BUILDKIT when doing local dev
- Added more rules to gitignore/dockerignore