### PR TITLE
Support for llama-cpp-python v0.1.69

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Install python bindings
-pip install llama-cpp-python==0.1.66
+pip install llama-cpp-python==0.1.69
 
 # Start Redis instance
 redis-server /etc/redis/redis.conf &


### PR DESCRIPTION
- Bump llama-cpp-python bindings to v0.1.69
- This brings support for newest fastapi/pydantic