### PR TITLE
Updated docker-compose tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ docker run -d \
     -v weights:/usr/src/app/weights \
     -v datadb:/data/db/ \
     -p 8008:8008 \
-    ghcr.io/serge-chat/serge:latest
+    ghcr.io/serge-chat/serge:main
 ```
 
 🐙 Docker Compose:
 ```yaml
 services:
   serge:
-    image: ghcr.io/serge-chat/serge:latest
+    image: ghcr.io/serge-chat/serge:main
     container_name: serge
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   serge:
-    image: ghcr.io/serge-chat/serge:latest
+    image: ghcr.io/serge-chat/serge:main
     container_name: serge
     restart: unless-stopped
     ports:


### PR DESCRIPTION
The tag for this dockerfile was set to `latest`; however, this tag does not exist. If you try to use this tag, you end up with a generic `manifest error`. 

The solution to this problem is to switch the tag to `main` instead. This gets the image to download correctly. 

Also updated the README to reflect this change.