### PR TITLE
Remove support for DragonflyDB

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,8 +3,8 @@
 FROM node:20-bullseye-slim as node_base
 
 # ---------------------------------------
-# Base image for dragonflydb
-FROM ghcr.io/dragonflydb/dragonfly:v1.8.0 as dragonfly
+# Base image for redis
+FROM redis:7-bullseye as redis
 
 # ---------------------------------------
 # Dev environment
@@ -17,17 +17,22 @@ ENV NODE_ENV='development'
 
 # Install dependencies
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libxml2 cmake build-essential dumb-init
+    && apt-get install -y --no-install-recommends cmake build-essential dumb-init
 
 # Copy database, source code, and scripts
-COPY --from=dragonfly /usr/local/bin/dragonfly /usr/local/bin/dragonfly
+COPY --from=redis /usr/local/bin/redis-server /usr/local/bin/redis-server
+COPY --from=redis /usr/local/bin/redis-cli /usr/local/bin/redis-cli
 COPY --from=node_base /usr/local /usr/local
 COPY scripts/dev.sh /usr/src/app/dev.sh
 COPY ./web/package.json ./web/package-lock.json ./
 
 RUN npm ci \
     && chmod 755 /usr/src/app/dev.sh \
-    && chmod 755 /usr/local/bin/dragonfly
+    && chmod 755 /usr/local/bin/redis-server \
+    && chmod 755 /usr/local/bin/redis-cli \
+    && mkdir -p /etc/redis \
+    && echo "appendonly yes" >> /etc/redis/redis.conf \
+    && echo "dir /data/db/" >> /etc/redis/redis.conf
 
 EXPOSE 8008
 EXPOSE 9124

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Serge is a chat interface crafted with [llama.cpp](https://github.com/ggerganov/llama.cpp) for running Alpaca models. No API keys, entirely self-hosted!
 
 - 🌐 **SvelteKit** frontend
-- 💾 **[Dragonfly](https://github.com/dragonflydb/dragonfly)** for storing chat history & parameters
+- 💾 **[Redis](https://github.com/redis/redis)** for storing chat history & parameters
 - ⚙️ **FastAPI + LangChain** for the API, wrapping calls to [llama.cpp](https://github.com/ggerganov/llama.cpp) using the [python bindings](https://github.com/abetlen/llama-cpp-python)
 
 🎥 Demo:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,9 +8,8 @@ pip install llama-cpp-python==0.1.78 || {
 	exit 1
 }
 
-# Start Dragonfly instance
-mkdir -p /data/db
-/usr/local/bin/dragonfly --noversion_check --logtostderr --dbnum 0 --bind localhost --port 6379 --save_schedule "*:*" --dbfilename dragonfly --dir /data/db &
+# Start Redis instance
+redis-server /etc/redis/redis.conf &
 
 # Start the API
 cd /usr/src/app/api || exit 1

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -14,9 +14,8 @@ pip install llama-cpp-python==0.1.78 || {
 	exit 1
 }
 
-# Start Dragonfly instance
-mkdir -p /data/db
-/usr/local/bin/dragonfly --noversion_check --logtostderr --dbnum 0 --bind localhost --port 6379 --save_schedule "*:*" --dbfilename dragonfly --dir /data/db &
+# Start Redis instance
+redis-server /etc/redis/redis.conf &
 
 # Start the web server
 cd /usr/src/app/web || exit 1


### PR DESCRIPTION
- Remove DragonflyDB support which break existing arm64 deployments
- Bundle the `redis-server` using the official Docker image.
- Update all scripts
- Update README
- Remove `libxml2` which was used by DragonflyDB