### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: '3'
 services:
   serge:
     image: ghcr.io/serge-chat/serge:latest


### PR DESCRIPTION
I am running: Debian 5.10.191-1

When trying to docker compose:

```
» docker-compose up -d  
ERROR: The Compose file './docker-compose.yml' is invalid because: Unsupported config option for volumes: 'datadb'
Unsupported config option for services: 'serge'
```

This article brought me to the solution: https://stackoverflow.com/questions/48311106/docker-compose-v3-unsupported-config-option-for-volumes