### PR TITLE
Fix installation of aarch64 wheels

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,11 +22,11 @@ detect_cpu_features() {
 
 # Check if the CPU architecture is aarch64/arm64
 if [ "$cpu_arch" = "aarch64" ]; then
-    pip_command="python -m pip install -v llama-cpp-python==$LLAMA_PYTHON_VERSION --only-binary=:all: --extra-index-url=https://gaby.github.io/arm64-wheels/"
+	pip_command="python -m pip install -v llama-cpp-python==$LLAMA_PYTHON_VERSION --only-binary=:all: --extra-index-url=https://gaby.github.io/arm64-wheels/"
 else
-    # Use @jllllll provided wheels
-    cpu_feature=$(detect_cpu_features)
-    pip_command="python -m pip install -v llama-cpp-python==$LLAMA_PYTHON_VERSION --only-binary=:all: --extra-index-url=https://jllllll.github.io/llama-cpp-python-cuBLAS-wheels/$cpu_feature/cpu"
+	# Use @jllllll provided wheels
+	cpu_feature=$(detect_cpu_features)
+	pip_command="python -m pip install -v llama-cpp-python==$LLAMA_PYTHON_VERSION --only-binary=:all: --extra-index-url=https://jllllll.github.io/llama-cpp-python-cuBLAS-wheels/$cpu_feature/cpu"
 fi
 
 echo "Recommended install command for llama-cpp-python: $pip_command"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -22,11 +22,11 @@ detect_cpu_features() {
 
 # Check if the CPU architecture is aarch64/arm64
 if [ "$cpu_arch" = "aarch64" ]; then
-    pip_command="python -m pip install -v llama-cpp-python==$LLAMA_PYTHON_VERSION --only-binary=:all: --extra-index-url=https://gaby.github.io/arm64-wheels/"
+	pip_command="python -m pip install -v llama-cpp-python==$LLAMA_PYTHON_VERSION --only-binary=:all: --extra-index-url=https://gaby.github.io/arm64-wheels/"
 else
-    # Use @jllllll provided wheels
-    cpu_feature=$(detect_cpu_features)
-    pip_command="python -m pip install -v llama-cpp-python==$LLAMA_PYTHON_VERSION --only-binary=:all: --extra-index-url=https://jllllll.github.io/llama-cpp-python-cuBLAS-wheels/$cpu_feature/cpu"
+	# Use @jllllll provided wheels
+	cpu_feature=$(detect_cpu_features)
+	pip_command="python -m pip install -v llama-cpp-python==$LLAMA_PYTHON_VERSION --only-binary=:all: --extra-index-url=https://jllllll.github.io/llama-cpp-python-cuBLAS-wheels/$cpu_feature/cpu"
 fi
 
 echo "Recommended install command for llama-cpp-python: $pip_command"


### PR DESCRIPTION
Use `https://gaby.github.io/arm64-wheels/` index for installing `aarch64` wheels of `llama-cpp-python`.