### PR TITLE
Fix inefficent model check during chat creation

### DIFF
--- a/api/src/serge/routers/chat.py
+++ b/api/src/serge/routers/chat.py
@@ -31,7 +31,7 @@ async def create_new_chat(
     n_threads: int = 4,
 ):
     if not os.path.exists(f"/usr/src/app/weights/{model}.bin"):
-        raisd ValueError(f"Model can't be found: /usr/src/app/weights/{model}.bin")
+        raise ValueError(f"Model can't be found: /usr/src/app/weights/{model}.bin")
 
     client = Redis(host="localhost", port=6379, decode_responses=False)
 

--- a/api/src/serge/routers/chat.py
+++ b/api/src/serge/routers/chat.py
@@ -30,13 +30,8 @@ async def create_new_chat(
     init_prompt: str = "Below is an instruction that describes a task. Write a response that appropriately completes the request.",
     n_threads: int = 4,
 ):
-    try:
-        client = Llama(
-            model_path=f"/usr/src/app/weights/{model}.bin",
-        )
-        del client
-    except Exception as exc:
-        raise ValueError(f"Model can't be found: {exc}")
+    if not os.path.exists(f"/usr/src/app/weights/{model}.bin"):
+        raisd ValueError(f"Model can't be found: /usr/src/app/weights/{model}.bin")
 
     client = Redis(host="localhost", port=6379, decode_responses=False)
 

--- a/api/src/serge/routers/chat.py
+++ b/api/src/serge/routers/chat.py
@@ -1,3 +1,5 @@
+import os
+
 from typing import Optional
 from fastapi import APIRouter, HTTPException
 from langchain.memory import RedisChatMessageHistory


### PR DESCRIPTION
Don't use llama-cpp to verify if model exists. This causes the model to be loaded into memory twice.