### PR TITLE
Fix ipv6 support conditional check

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -51,7 +51,7 @@ redis_process=$!
 # Start the API
 cd /usr/src/app/api || exit 1
 hypercorn_cmd="hypercorn src.serge.main:app --bind 0.0.0.0:8008"
-[ "$SERGE_ENABLE_IPV6" = false ] && hypercorn_cmd+=" --bind [::]:8008"
+[ "$SERGE_ENABLE_IPV6" = true ] && hypercorn_cmd+=" --bind [::]:8008"
 
 $hypercorn_cmd || {
 	echo 'Failed to start main app'


### PR DESCRIPTION
The condition must be true not false to add the support of IPv6.